### PR TITLE
GH-35 fixed: bug with generated copy link from profile page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - No changes.
 
+## [0.0.6] - 2025-08-19
+
+### Fixed
+
+- Fixed bug with copy link that is generated when you attempt to copy the link for a deck from your profile page. The new link will only use the deckId instead of the generated userId and deckId combination [e56cb27](https://github.com/scottwestover/backrooms-tcg-deck-builder/pull/36/commits/e56cb27349acdb847609cec5ed901843f93e1a07).
+
 ## [0.0.5] - 2025-08-18
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backrooms-tcg-deck-builder",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --c development",

--- a/src/app/features/shared/dialogs/deck-dialog.component.ts
+++ b/src/app/features/shared/dialogs/deck-dialog.component.ts
@@ -383,11 +383,14 @@ export class DeckDialogComponent {
     selBox.style.left = '0';
     selBox.style.top = '0';
     selBox.style.opacity = '0';
-    selBox.value = this.editable
-      ? `${DOMAIN}/deckbuilder/user/${this.authService.userData?.uid}/deck/${
-          this.deck.docId || this.deck.id
-        }`
-      : `${DOMAIN}/deckbuilder/${this.deck.docId || this.deck.id}`;
+    // GH-35 copy link includes userId, which breaks if others try to view this users deck
+    // selBox.value = this.editable
+    //   ? `${DOMAIN}/deckbuilder/user/${this.authService.userData?.uid}/deck/${
+    //       this.deck.docId || this.deck.id
+    //     }`
+    //   : `${DOMAIN}/deckbuilder/${this.deck.docId || this.deck.id}`;
+
+    selBox.value = `${DOMAIN}/deckbuilder/${this.deck.docId || this.deck.id}`;
     document.body.appendChild(selBox);
     selBox.focus();
     selBox.select();

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,7 +31,7 @@ import {
   withPreloading,
 } from '@angular/router';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { provideStoreDevtools } from '@ngrx/store-devtools';
+// import { provideStoreDevtools } from '@ngrx/store-devtools';
 import 'hammerjs';
 import { ToastrModule } from 'ngx-toastr';
 import { ConfirmationService, MessageService } from 'primeng/api';


### PR DESCRIPTION
Updated the link that is generated on the profile page to just use the deckId. For the time being, left the previous code in place commented out.

Previously, the generated link would be something like https://backrooms-tcg-deckbuilder.web.app/deckbuilder/user/yXd0GuWCPqelzpdofntr1vRN10F2/deck/666040b9-84ee-47fb-9c20-5ad9b5ee8ac6::yXd0GuWCPqelzpdofntr1vRN10F2, which would break if a different user tried to view the deck.

