### PR TITLE
[GH-41] various bug fixes and improvements

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -17,6 +17,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
+            "allowedCommonJsDependencies": ["file-saver", "uuid"],
             "outputPath": "dist/backrooms-tcg-deck-builder",
             "index": "src/index.html",
             "main": "src/main.ts",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "test:once": "ng test --watch=false",
+    "test:once": "ng test --browsers=ChromeHeadless --watch=false",
     "lint": "ng lint --fix",
     "format": "npx prettier src/**/*.{js,jsx,ts,tsx,html,css,scss} --write",
     "deploy:host": "npx firebase deploy --only hosting",

--- a/src/app/features/deckbuilder/deckbuilder-page.component.spec.ts
+++ b/src/app/features/deckbuilder/deckbuilder-page.component.spec.ts
@@ -1,0 +1,178 @@
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { BehaviorSubject, of } from 'rxjs';
+import { DeckbuilderPageComponent } from './deckbuilder-page.component';
+import { BackroomsBackendService } from '../../services/backrooms-backend.service';
+import { WebsiteStore } from '../../store/website.store';
+import { AuthService } from '../../services/auth.service';
+import { Meta, Title } from '@angular/platform-browser';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { IDeck, ISave, emptySave } from '../../../models';
+import { ToastrModule } from 'ngx-toastr';
+
+describe('DeckbuilderPageComponent', () => {
+  let component: DeckbuilderPageComponent;
+  let fixture: ComponentFixture<DeckbuilderPageComponent>;
+  let backendService: jasmine.SpyObj<BackroomsBackendService>;
+  let websiteStore: jasmine.SpyObj<InstanceType<typeof WebsiteStore>>;
+  let authService: jasmine.SpyObj<AuthService>;
+  let routeParams: BehaviorSubject<any>;
+
+  const mockDeckId = 'deck123';
+  const mockUserId = 'user123';
+
+  const mockDeck: IDeck = {
+    id: mockDeckId,
+    title: 'Test Deck',
+    cards: [],
+    userId: mockUserId,
+    description: '',
+    docId: '',
+    imageCardId: '',
+    user: '',
+    date: '',
+  };
+
+  const mockSave: ISave = {
+    ...emptySave,
+    uid: mockUserId,
+    decks: [mockDeck],
+  };
+
+  beforeEach(async () => {
+    routeParams = new BehaviorSubject({});
+    const backendServiceSpy = jasmine.createSpyObj('BackroomsBackendService', [
+      'getSave',
+      'getDeck',
+    ]);
+    const websiteStoreSpy = jasmine.createSpyObj('WebsiteStore', [
+      'deck',
+      'updateDeck',
+    ]);
+    const authServiceSpy = jasmine.createSpyObj('AuthService', [], {
+      userData: null,
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [DeckbuilderPageComponent, ToastrModule.forRoot()],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            params: routeParams.asObservable(),
+          },
+        },
+        { provide: BackroomsBackendService, useValue: backendServiceSpy },
+        { provide: WebsiteStore, useValue: websiteStoreSpy },
+        { provide: AuthService, useValue: authServiceSpy },
+        { provide: Meta, useValue: jasmine.createSpyObj('Meta', ['addTags']) },
+        {
+          provide: Title,
+          useValue: jasmine.createSpyObj('Title', ['setTitle']),
+        },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DeckbuilderPageComponent);
+    component = fixture.componentInstance;
+    backendService = TestBed.inject(
+      BackroomsBackendService,
+    ) as jasmine.SpyObj<BackroomsBackendService>;
+    websiteStore = TestBed.inject(WebsiteStore) as jasmine.SpyObj<
+      InstanceType<typeof WebsiteStore>
+    >;
+    authService = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('checkUrl$ observable', () => {
+    it('should do nothing if no relevant params are present', fakeAsync(() => {
+      routeParams.next({});
+      component.checkUrl$.subscribe();
+      tick();
+
+      expect(backendService.getSave).not.toHaveBeenCalled();
+      expect(backendService.getDeck).not.toHaveBeenCalled();
+      expect(websiteStore.updateDeck).not.toHaveBeenCalled();
+    }));
+
+    it('should load from getSave when userId and deckId are in params', fakeAsync(() => {
+      backendService.getSave.and.returnValue(of(mockSave));
+      routeParams.next({ userId: mockUserId, deckId: mockDeckId });
+
+      component.checkUrl$.subscribe();
+      tick();
+
+      expect(backendService.getSave).toHaveBeenCalledWith(mockUserId);
+      expect(websiteStore.updateDeck).toHaveBeenCalledWith(
+        jasmine.objectContaining({ title: mockDeck.title }),
+      );
+    }));
+
+    it('should generate a new ID if the user is different (from getSave)', fakeAsync(() => {
+      backendService.getSave.and.returnValue(of(mockSave));
+      Object.defineProperty(authService, 'userData', {
+        value: { uid: 'differentUser' },
+        configurable: true,
+      });
+      routeParams.next({ userId: mockUserId, deckId: mockDeckId });
+
+      component.checkUrl$.subscribe();
+      tick();
+
+      const updatedDeck = websiteStore.updateDeck.calls.argsFor(0)[0];
+      expect(updatedDeck.id).not.toBe(mockDeckId);
+    }));
+
+    it('should load from local store if deck ID matches', fakeAsync(() => {
+      websiteStore.deck.and.returnValue(mockDeck);
+      routeParams.next({ id: mockDeckId });
+
+      component.checkUrl$.subscribe();
+      tick();
+
+      expect(websiteStore.deck).toHaveBeenCalled();
+      expect(backendService.getDeck).not.toHaveBeenCalled();
+      expect(websiteStore.updateDeck).toHaveBeenCalledWith(
+        jasmine.objectContaining({ title: mockDeck.title }),
+      );
+    }));
+
+    it('should load from backend if not in local store', fakeAsync(() => {
+      websiteStore.deck.and.returnValue({ id: 'another-deck' } as IDeck);
+      backendService.getDeck.and.returnValue(of(mockDeck));
+      routeParams.next({ id: mockDeckId });
+
+      component.checkUrl$.subscribe();
+      tick();
+
+      expect(websiteStore.deck).toHaveBeenCalled();
+      expect(backendService.getDeck).toHaveBeenCalledWith(mockDeckId);
+      expect(websiteStore.updateDeck).toHaveBeenCalledWith(
+        jasmine.objectContaining({ title: mockDeck.title }),
+      );
+    }));
+
+    it('should not update deck if not found anywhere', fakeAsync(() => {
+      websiteStore.deck.and.returnValue({ id: 'another-deck' } as IDeck);
+      backendService.getDeck.and.returnValue(of(undefined as any));
+      routeParams.next({ id: 'non-existent-deck' });
+
+      component.checkUrl$.subscribe();
+      tick();
+
+      expect(websiteStore.deck).toHaveBeenCalled();
+      expect(backendService.getDeck).toHaveBeenCalledWith('non-existent-deck');
+      expect(websiteStore.updateDeck).not.toHaveBeenCalled();
+    }));
+  });
+});

--- a/src/app/features/deckbuilder/deckbuilder-page.component.ts
+++ b/src/app/features/deckbuilder/deckbuilder-page.component.ts
@@ -95,17 +95,25 @@ export class DeckbuilderPageComponent implements OnInit {
         return this.backroomsBackendService.getSave(params['userId']);
       } else if (params['id']) {
         this.deckId = params['id'].split('::')[0];
-        return this.backroomsBackendService.getDeck(params['id']).pipe(
-          map((deck) => {
-            return { ...emptySave, decks: [deck] };
-          }),
-        );
+        const localDeck = this.websiteStore.deck();
+        if (localDeck && localDeck.id === this.deckId) {
+          return of({ ...emptySave, decks: [localDeck] });
+        } else {
+          return this.backroomsBackendService.getDeck(params['id']).pipe(
+            map((deck) => {
+              if (!deck) {
+                return { ...emptySave, decks: [] };
+              }
+              return { ...emptySave, decks: [deck] };
+            }),
+          );
+        }
       } else {
         return of(emptySave);
       }
     }),
     tap((save) => {
-      if (save.decks.length === 0) return;
+      if (!save || !save.decks || save.decks.length === 0) return;
       const foundDeck = save.decks.find((deck) => deck.id === this.deckId);
       if (!foundDeck) return;
 

--- a/src/app/features/randomizer/components/randomizer-manual-controls.component.ts
+++ b/src/app/features/randomizer/components/randomizer-manual-controls.component.ts
@@ -19,6 +19,7 @@ import { Archetype, ArchetypeData } from '../../../services/randomizer.service';
           >Overall Deck:</label
         >
         <select
+          id="overall-select"
           name="overall-select"
           [ngModel]="overallSelection"
           (ngModelChange)="onOverallSelectionChange($event)"
@@ -37,6 +38,7 @@ import { Archetype, ArchetypeData } from '../../../services/randomizer.service';
           >Rooms Archetype:</label
         >
         <select
+          id="rooms-select"
           name="rooms-select"
           [ngModel]="manualSelections.rooms"
           (ngModelChange)="onSelectionChange('rooms', $event)"
@@ -54,6 +56,7 @@ import { Archetype, ArchetypeData } from '../../../services/randomizer.service';
           >Items Archetype:</label
         >
         <select
+          id="items-select"
           name="items-select"
           [ngModel]="manualSelections.items"
           (ngModelChange)="onSelectionChange('items', $event)"
@@ -71,6 +74,7 @@ import { Archetype, ArchetypeData } from '../../../services/randomizer.service';
           >Entities Archetype:</label
         >
         <select
+          id="entities-select"
           name="entities-select"
           [ngModel]="manualSelections.entities"
           (ngModelChange)="onSelectionChange('entities', $event)"
@@ -88,6 +92,7 @@ import { Archetype, ArchetypeData } from '../../../services/randomizer.service';
           >Outcomes Archetype:</label
         >
         <select
+          id="outcomes-select"
           name="outcomes-select"
           [ngModel]="manualSelections.outcomes"
           (ngModelChange)="onSelectionChange('outcomes', $event)"

--- a/src/app/features/shared/dialogs/export-deck-dialog.component.ts
+++ b/src/app/features/shared/dialogs/export-deck-dialog.component.ts
@@ -1,7 +1,6 @@
 import { NgClass, NgIf } from '@angular/common';
 import { Component, OnInit, effect, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { saveAs } from 'file-saver';
 import { ButtonModule } from 'primeng/button';
 import { InputTextareaModule } from 'primeng/inputtextarea';
 import { SelectButtonModule } from 'primeng/selectbutton';
@@ -173,7 +172,8 @@ export class ExportDeckDialogComponent implements OnInit {
     }
   }
 
-  exportDeckToFile(): void {
+  async exportDeckToFile(): Promise<void> {
+    const { saveAs } = await import('file-saver');
     let blob = new Blob([this.deckText], { type: 'text/txt' });
     saveAs(blob, this.deck.title + '.txt');
   }

--- a/src/app/functions/deck-factory.function.spec.ts
+++ b/src/app/functions/deck-factory.function.spec.ts
@@ -1,0 +1,68 @@
+import { createDeckFromGenerated } from './deck-factory.function';
+import {
+  GeneratedDeck,
+  GeneratedMixedDeck,
+} from '../services/randomizer.service';
+import { ICountCard } from '../../models';
+import * as uuid from 'uuid';
+
+describe('createDeckFromGenerated', () => {
+  const mockDate = new Date('2023-01-01T00:00:00.000Z');
+
+  beforeEach(() => {
+    jasmine.clock().install();
+    jasmine.clock().mockDate(mockDate);
+  });
+
+  afterEach(() => {
+    jasmine.clock().uninstall();
+  });
+
+  it('should create a deck from a simple GeneratedDeck', () => {
+    const generatedDeck: GeneratedDeck & { cards: ICountCard[] } = {
+      archetypeName: 'Test Archetype',
+      cards: [{ id: 'C01', count: 2 }],
+    };
+
+    const result = createDeckFromGenerated(generatedDeck);
+
+    expect(result.id).toEqual(jasmine.any(String));
+    expect(result.title).toBe('Test Archetype');
+    expect(result.description).toBe('A randomly generated deck.');
+    expect(result.cards).toEqual([{ id: 'C01', count: 2 }]);
+    expect(result.date).toEqual(mockDate.toISOString());
+    expect(result.imageCardId).toBe('C01');
+  });
+
+  it('should create a deck from a GeneratedMixedDeck', () => {
+    const generatedDeck: GeneratedMixedDeck & { cards: ICountCard[] } = {
+      archetypeNames: {
+        rooms: 'Room Archetype',
+        items: 'Item Archetype',
+        entities: 'Entity Archetype',
+        outcomes: 'Outcome Archetype',
+      },
+      cards: [{ id: 'C02', count: 1 }],
+    };
+
+    const result = createDeckFromGenerated(generatedDeck);
+
+    expect(result.id).toEqual(jasmine.any(String));
+    expect(result.title).toBe('Mixed Random Deck');
+    expect(result.description).toBe('A randomly generated deck.');
+    expect(result.cards).toEqual([{ id: 'C02', count: 1 }]);
+    expect(result.date).toEqual(mockDate.toISOString());
+    expect(result.imageCardId).toBe('C02');
+  });
+
+  it('should use a fallback imageCardId if the deck has no cards', () => {
+    const generatedDeck: GeneratedDeck & { cards: ICountCard[] } = {
+      archetypeName: 'Empty Archetype',
+      cards: [],
+    };
+
+    const result = createDeckFromGenerated(generatedDeck);
+
+    expect(result.imageCardId).toBe('LL-001');
+  });
+});

--- a/src/app/functions/deck-factory.function.ts
+++ b/src/app/functions/deck-factory.function.ts
@@ -1,0 +1,25 @@
+import * as uuid from 'uuid';
+import { ICountCard, IDeck } from '../../models';
+import {
+  GeneratedDeck,
+  GeneratedMixedDeck,
+} from '../services/randomizer.service';
+
+export function createDeckFromGenerated(
+  generatedDeck: (GeneratedDeck | GeneratedMixedDeck) & { cards: ICountCard[] },
+): IDeck {
+  return {
+    id: uuid.v4(),
+    title:
+      'archetypeNames' in generatedDeck
+        ? 'Mixed Random Deck'
+        : generatedDeck.archetypeName,
+    description: 'A randomly generated deck.',
+    cards: generatedDeck.cards,
+    date: new Date().toISOString(),
+    user: '',
+    userId: '',
+    imageCardId: generatedDeck.cards[0]?.id ?? 'LL-001',
+    docId: '',
+  };
+}

--- a/src/app/functions/deck-view-transformer.function.spec.ts
+++ b/src/app/functions/deck-view-transformer.function.spec.ts
@@ -1,0 +1,161 @@
+import { transformDeckViews } from './deck-view-transformer.function';
+import { BackroomsCardStore } from '../store/backrooms-card.store';
+import { ICountCard, IDeckCard } from '../../models';
+
+describe('transformDeckViews', () => {
+  let cardStoreMock: jasmine.SpyObj<InstanceType<typeof BackroomsCardStore>>;
+  const mockCardsMap = new Map<string, IDeckCard>([
+    [
+      'R01',
+      { id: 'R01', name: { english: 'Room 1' }, cardType: 'Room' } as IDeckCard,
+    ],
+    [
+      'I01',
+      { id: 'I01', name: { english: 'Item 1' }, cardType: 'Item' } as IDeckCard,
+    ],
+    [
+      'E01',
+      {
+        id: 'E01',
+        name: { english: 'Entity 1' },
+        cardType: 'Entity',
+      } as IDeckCard,
+    ],
+    [
+      'O01',
+      {
+        id: 'O01',
+        name: { english: 'Outcome 1' },
+        cardType: 'Outcome',
+      } as IDeckCard,
+    ],
+  ]);
+
+  beforeEach(() => {
+    const cardStoreSpy = jasmine.createSpyObj('BackroomsCardStore', [
+      'cardsMap',
+    ]);
+    cardStoreSpy.cardsMap.and.returnValue(mockCardsMap);
+    cardStoreMock = cardStoreSpy;
+  });
+
+  it('should return null views if input cards are null', () => {
+    const result = transformDeckViews(null, cardStoreMock);
+    expect(result.generatedCards).toBeNull();
+    expect(result.generatedDeckAsList).toBeNull();
+  });
+
+  it('should return empty views if input cards are empty', () => {
+    const result = transformDeckViews([], cardStoreMock);
+    expect(result.generatedCards).toEqual({
+      rooms: [],
+      items: [],
+      entities: [],
+      outcomes: [],
+    });
+    expect(result.generatedDeckAsList).toEqual({
+      rooms: [],
+      items: [],
+      entities: [],
+      outcomes: [],
+    });
+  });
+
+  it('should correctly transform and categorize a list of cards', () => {
+    const inputCards: ICountCard[] = [
+      { id: 'R01', count: 2 },
+      { id: 'I01', count: 1 },
+      { id: 'E01', count: 3 },
+      { id: 'O01', count: 1 },
+      { id: 'UNKNOWN', count: 1 }, // Card not in map
+    ];
+
+    const result = transformDeckViews(inputCards, cardStoreMock);
+
+    // Check generatedCards (image view)
+    expect(result.generatedCards?.rooms.length).toBe(1);
+    expect(result.generatedCards?.rooms[0]).toEqual({
+      ...mockCardsMap.get('R01')!,
+      count: 2,
+    });
+
+    expect(result.generatedCards?.items.length).toBe(1);
+    expect(result.generatedCards?.items[0]).toEqual({
+      ...mockCardsMap.get('I01')!,
+      count: 1,
+    });
+
+    expect(result.generatedCards?.entities.length).toBe(1);
+    expect(result.generatedCards?.entities[0]).toEqual({
+      ...mockCardsMap.get('E01')!,
+      count: 3,
+    });
+
+    expect(result.generatedCards?.outcomes.length).toBe(1);
+    expect(result.generatedCards?.outcomes[0]).toEqual({
+      ...mockCardsMap.get('O01')!,
+      count: 1,
+    });
+
+    // Check generatedDeckAsList (list view)
+    expect(result.generatedDeckAsList?.rooms.length).toBe(1);
+    expect(result.generatedDeckAsList?.rooms[0]).toEqual({
+      id: 'R01',
+      name: 'Room 1',
+      count: 2,
+    });
+
+    expect(result.generatedDeckAsList?.items.length).toBe(1);
+    expect(result.generatedDeckAsList?.items[0]).toEqual({
+      id: 'I01',
+      name: 'Item 1',
+      count: 1,
+    });
+
+    expect(result.generatedDeckAsList?.entities.length).toBe(1);
+    expect(result.generatedDeckAsList?.entities[0]).toEqual({
+      id: 'E01',
+      name: 'Entity 1',
+      count: 3,
+    });
+
+    expect(result.generatedDeckAsList?.outcomes.length).toBe(1);
+    expect(result.generatedDeckAsList?.outcomes[0]).toEqual({
+      id: 'O01',
+      name: 'Outcome 1',
+      count: 1,
+    });
+  });
+
+  it('should handle case-insensitivity for card types', () => {
+    const mixedCaseMap = new Map<string, IDeckCard>([
+      [
+        'R01',
+        {
+          id: 'R01',
+          name: { english: 'Room 1' },
+          cardType: 'Room',
+        } as IDeckCard,
+      ],
+      [
+        'I01',
+        {
+          id: 'I01',
+          name: { english: 'Item 1' },
+          cardType: 'item',
+        } as IDeckCard,
+      ],
+    ]);
+    cardStoreMock.cardsMap.and.returnValue(mixedCaseMap);
+
+    const inputCards: ICountCard[] = [
+      { id: 'R01', count: 1 },
+      { id: 'I01', count: 1 },
+    ];
+
+    const result = transformDeckViews(inputCards, cardStoreMock);
+
+    expect(result.generatedCards?.rooms.length).toBe(1);
+    expect(result.generatedCards?.items.length).toBe(1);
+  });
+});

--- a/src/app/functions/deck-view-transformer.function.ts
+++ b/src/app/functions/deck-view-transformer.function.ts
@@ -1,0 +1,82 @@
+import { ICountCard, IDeckCard } from '../../models';
+import { BackroomsCardStore } from '../store/backrooms-card.store';
+
+export interface DeckAsList {
+  id: string;
+  name: string;
+  count: number;
+}
+
+export interface TransformedDeckViews {
+  generatedCards: {
+    rooms: IDeckCard[];
+    items: IDeckCard[];
+    entities: IDeckCard[];
+    outcomes: IDeckCard[];
+  } | null;
+  generatedDeckAsList: {
+    rooms: DeckAsList[];
+    items: DeckAsList[];
+    entities: DeckAsList[];
+    outcomes: DeckAsList[];
+  } | null;
+}
+
+export function transformDeckViews(
+  cards: ICountCard[] | null,
+  cardStore: InstanceType<typeof BackroomsCardStore>,
+): TransformedDeckViews {
+  if (!cards) {
+    return {
+      generatedCards: null,
+      generatedDeckAsList: null,
+    };
+  }
+
+  const cardMap = cardStore.cardsMap();
+  const rooms: IDeckCard[] = [];
+  const items: IDeckCard[] = [];
+  const entities: IDeckCard[] = [];
+  const outcomes: IDeckCard[] = [];
+  const listRooms: DeckAsList[] = [];
+  const listItems: DeckAsList[] = [];
+  const listEntities: DeckAsList[] = [];
+  const listOutcomes: DeckAsList[] = [];
+
+  for (const countCard of cards) {
+    const card = cardMap.get(countCard.id);
+
+    if (card) {
+      const deckCard: IDeckCard = { ...card, count: countCard.count };
+      const deckAsListCard = {
+        id: card.id,
+        name: card.name.english,
+        count: countCard.count,
+      };
+
+      if (card.cardType.toLowerCase() === 'room') {
+        rooms.push(deckCard);
+        listRooms.push(deckAsListCard);
+      } else if (card.cardType.toLowerCase() === 'item') {
+        items.push(deckCard);
+        listItems.push(deckAsListCard);
+      } else if (card.cardType.toLowerCase() === 'entity') {
+        entities.push(deckCard);
+        listEntities.push(deckAsListCard);
+      } else if (card.cardType.toLowerCase() === 'outcome') {
+        outcomes.push(deckCard);
+        listOutcomes.push(deckAsListCard);
+      }
+    }
+  }
+
+  return {
+    generatedCards: { rooms, items, entities, outcomes },
+    generatedDeckAsList: {
+      rooms: listRooms,
+      items: listItems,
+      entities: listEntities,
+      outcomes: listOutcomes,
+    },
+  };
+}

--- a/src/app/services/backrooms-backend.service.ts
+++ b/src/app/services/backrooms-backend.service.ts
@@ -3,7 +3,6 @@ import { inject, Injectable } from '@angular/core';
 import { Firestore, getDoc } from '@angular/fire/firestore';
 import { first, from, Observable, of } from 'rxjs';
 import {
-  IColor,
   ICountCard,
   IDeck,
   IDeckFireStore,

--- a/src/app/services/randomizer.service.ts
+++ b/src/app/services/randomizer.service.ts
@@ -124,4 +124,103 @@ export class RandomizerService {
       cards: cards,
     };
   }
+
+  public isMixedDeck(
+    deck: GeneratedDeck | GeneratedMixedDeck,
+  ): deck is GeneratedMixedDeck {
+    return 'archetypeNames' in deck;
+  }
+
+  public findArchetypeKeyByName(
+    name: string,
+    archetypes: ArchetypeData,
+  ): string | null {
+    return (
+      archetypes.find((archetype) => archetype.name === name)?.id.toString() ??
+      null
+    );
+  }
+
+  generateDeck(
+    generationMode: 'simple' | 'mixed' | 'manual',
+    archetypes: ArchetypeData,
+    manualSelections?: {
+      rooms: string | null;
+      items: string | null;
+      entities: string | null;
+      outcomes: string | null;
+    },
+  ): (GeneratedDeck | GeneratedMixedDeck) & { cards: ICountCard[] } {
+    if (generationMode === 'simple') {
+      return this.generateSimpleDeck(archetypes);
+    } else if (generationMode === 'mixed') {
+      return this.generateMixedDeck(archetypes);
+    } else if (generationMode === 'manual' && manualSelections) {
+      const { rooms, items, entities, outcomes } = manualSelections;
+
+      if (rooms && items && entities && outcomes) {
+        // Find archetypes by ID (string representation)
+        const roomArchetype = archetypes.find((a) => a.id.toString() === rooms);
+        const itemArchetype = archetypes.find((a) => a.id.toString() === items);
+        const entityArchetype = archetypes.find(
+          (a) => a.id.toString() === entities,
+        );
+        const outcomeArchetype = archetypes.find(
+          (a) => a.id.toString() === outcomes,
+        );
+
+        if (
+          !roomArchetype ||
+          !itemArchetype ||
+          !entityArchetype ||
+          !outcomeArchetype
+        ) {
+          console.error(
+            'One or more archetypes not found for manual selection.',
+          );
+          // Return a default empty deck or throw an error
+          return {
+            archetypeName: 'Error Deck',
+            cards: [],
+          } as GeneratedDeck & { cards: ICountCard[] };
+        }
+
+        const roomCards = roomArchetype.rooms;
+        const itemCards = itemArchetype.items;
+        const entityCards = entityArchetype.entities;
+        const outcomeCards = outcomeArchetype.outcomes;
+        const allCards = [
+          ...roomCards,
+          ...itemCards,
+          ...entityCards,
+          ...outcomeCards,
+        ];
+
+        const allSame =
+          rooms === items && rooms === entities && rooms === outcomes;
+
+        if (allSame) {
+          return {
+            archetypeName: roomArchetype.name,
+            cards: allCards,
+          };
+        } else {
+          return {
+            archetypeNames: {
+              rooms: roomArchetype.name,
+              items: itemArchetype.name,
+              entities: entityArchetype.name,
+              outcomes: outcomeArchetype.name,
+            },
+            cards: allCards,
+          };
+        }
+      }
+    }
+    // Default return for cases where manual selections are incomplete or mode is not recognized
+    return {
+      archetypeName: 'Unknown Archetype',
+      cards: [],
+    };
+  }
 }

--- a/src/app/services/url-sync.service.spec.ts
+++ b/src/app/services/url-sync.service.spec.ts
@@ -1,0 +1,62 @@
+import { TestBed } from '@angular/core/testing';
+import { Router, ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
+import { UrlSyncService } from './url-sync.service';
+
+describe('UrlSyncService', () => {
+  let service: UrlSyncService;
+  let router: jasmine.SpyObj<Router>;
+  let route: ActivatedRoute;
+
+  beforeEach(() => {
+    const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    const activatedRouteStub = {
+      queryParams: of({ rooms: '1' }),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        UrlSyncService,
+        { provide: Router, useValue: routerSpy },
+        { provide: ActivatedRoute, useValue: activatedRouteStub },
+      ],
+    });
+
+    service = TestBed.inject(UrlSyncService);
+    router = TestBed.inject(Router) as jasmine.SpyObj<Router>;
+    route = TestBed.inject(ActivatedRoute);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('getQueryParams', () => {
+    it('should return an observable of query params from ActivatedRoute', (done) => {
+      service.getQueryParams().subscribe((params) => {
+        expect(params).toEqual({ rooms: '1' });
+        done();
+      });
+    });
+  });
+
+  describe('updateUrlWithSelections', () => {
+    it('should call router.navigate with the correct parameters', () => {
+      const selections = {
+        rooms: '1',
+        items: '2',
+        entities: null,
+        outcomes: null,
+      };
+
+      service.updateUrlWithSelections(selections);
+
+      expect(router.navigate).toHaveBeenCalledWith([], {
+        relativeTo: route,
+        queryParams: selections,
+        queryParamsHandling: 'merge',
+        replaceUrl: true,
+      });
+    });
+  });
+});

--- a/src/app/services/url-sync.service.ts
+++ b/src/app/services/url-sync.service.ts
@@ -1,0 +1,29 @@
+import { Injectable, inject } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class UrlSyncService {
+  private router = inject(Router);
+  private route = inject(ActivatedRoute);
+
+  getQueryParams(): Observable<any> {
+    return this.route.queryParams;
+  }
+
+  updateUrlWithSelections(selections: {
+    rooms: string | null;
+    items: string | null;
+    entities: string | null;
+    outcomes: string | null;
+  }): void {
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: selections,
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
+  }
+}


### PR DESCRIPTION
Fixed the bug with loading randomized decks in the deck builder view. The issue spawned from unhandled edge cases in the deck builder app page when: the provided deck id was for a local storage deck and not a firestore deck, and if the deck id does not exist then we would create an undefined deck.

To fix this, we now only create the deck if found, and we added a pre-check to see if the provided id is for a local storage deck, which should be fine since decks we share are a combination of userid and deckid.

Added new unit tests for the deckbuilder page.

Refactored more logic out of the randomizer page into separate functions and services.