### PR TITLE
[GH-47] fixed bug with export deck to file

### DIFF
--- a/src/app/features/shared/dialogs/export-deck-dialog.component.ts
+++ b/src/app/features/shared/dialogs/export-deck-dialog.component.ts
@@ -1,6 +1,7 @@
 import { NgClass, NgIf } from '@angular/common';
 import { Component, OnInit, effect, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { saveAs } from 'file-saver';
 import { ButtonModule } from 'primeng/button';
 import { InputTextareaModule } from 'primeng/inputtextarea';
 import { SelectButtonModule } from 'primeng/selectbutton';
@@ -172,8 +173,7 @@ export class ExportDeckDialogComponent implements OnInit {
     }
   }
 
-  async exportDeckToFile(): Promise<void> {
-    const { saveAs } = await import('file-saver');
+  exportDeckToFile(): void {
     let blob = new Blob([this.deckText], { type: 'text/txt' });
     saveAs(blob, this.deck.title + '.txt');
   }


### PR DESCRIPTION
Fixed bug with the export deck to file feature that was broken as part of the changes introduced for
the deck randomization feature.

The issue was tied to trying to lazy load the import which broke the feature. For the time being, the
change was reverted and the lazy loading can be
reviewed at a later time.

fixes: https://github.com/scottwestover/backrooms-tcg-deck-builder/issues/47